### PR TITLE
also overwrite name in setDisplayName

### DIFF
--- a/src/__tests__/setDisplayName.spec.js
+++ b/src/__tests__/setDisplayName.spec.js
@@ -6,6 +6,7 @@ it('should create named action', async () => {
 
   const action = setDisplayName('sayCool', cool);
 
+  expect(action).toHaveProperty('name', 'sayCool');
   expect(action).toHaveProperty('displayName', 'sayCool');
 });
 

--- a/src/setDisplayName.js
+++ b/src/setDisplayName.js
@@ -3,6 +3,7 @@ const curry = require('lodash/curry');
 const setDisplayName = (displayName, action) => {
   /* eslint-disable no-param-reassign */
   action.displayName = displayName;
+  Object.defineProperty(action, 'name', { value: displayName });
   /* eslint-enable no-param-reassign */
 
   return action;


### PR DESCRIPTION
We should overwrite those two.
```js
console.log(action);
// [Function: name]
```