### PR TITLE
fallback to empty string when template getting falsy value

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -18,7 +18,7 @@ describe('#isValidTemplate', () => {
       true
     );
     expect(isValidTemplate('Hi, {{session.user.first_name}}')).toBe(true);
-    // expect(isValidTemplate('Hi, {{user.first_name}}')).toBe(true);
+    expect(isValidTemplate('Hi, {{user.first_name}}')).toBe(true);
     expect(isValidTemplate('Hi, {{context.event.text}}')).toBe(true);
     expect(isValidTemplate('Hi, {{event.text}}')).toBe(true);
     expect(isValidTemplate('Hi, {{context.state.xxx}}')).toBe(true);
@@ -82,6 +82,10 @@ describe('#compileTemplate', () => {
     expectTemplate('Hi, {{event.text}}').toBe('Hi, Cool');
     expectTemplate('Hi, {{context.state.xxx}}').toBe('Hi, yyy');
     expectTemplate('Hi, {{state.xxx}}').toBe('Hi, yyy');
+  });
+
+  it('should fallback falsy value into empty string', () => {
+    expectTemplate('Hi, {{context.session.user.last_name}}').toBe('Hi, ');
   });
 
   it('should allow whitespaces', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,7 +43,7 @@ exports.compileTemplate = tpl => context => {
       contextKeyPrefixResolveMap[firstWhitelistKey]
     }${otherResults[0].slice(1)}`;
 
-    const value = get(context, properties);
+    const value = get(context, properties, '');
 
     warning(
       typeof value === 'string',


### PR DESCRIPTION
you wont see `hi, undefined` any more