### PR TITLE
implement attachOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,23 @@ bot.onEvent(
 );
 ```
 
+### `attachOptions`
+
+Attaches additional options to the action.
+
+```js
+const { attachOptions, sendText } = require('bottender-compose');
+
+bot.onEvent(
+  attachOptions({ tag: 'ISSUE_RESOLUTION' }, sendText('Issue Resolved'))
+);
+
+// curry function
+const attachIssueResolutionTag = attachOptions({ tag: 'ISSUE_RESOLUTION' });
+
+bot.onEvent(attachIssueResolutionTag(sendText('Issue Resolved')));
+```
+
 ### Logger Methods
 
 ```js

--- a/src/__tests__/attachOptions.spec.js
+++ b/src/__tests__/attachOptions.spec.js
@@ -1,0 +1,91 @@
+const attachOptions = require('../attachOptions');
+const { sendText } = require('../');
+
+it('should create action that will call sendText and tag', async () => {
+  const action = attachOptions({ tag: 'ISSUE_RESOLUTION' }, sendText('haha'));
+  const context = {
+    sendText: jest.fn(() => Promise.resolve()),
+  };
+
+  await action(context);
+
+  expect(context.sendText).toBeCalledWith('haha', { tag: 'ISSUE_RESOLUTION' });
+});
+
+it('should merge original options', async () => {
+  const action = attachOptions(
+    { tag: 'ISSUE_RESOLUTION' },
+    sendText('haha', {
+      quick_replies: [
+        {
+          content_type: 'text',
+          title: 'Red',
+          payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED',
+        },
+      ],
+    })
+  );
+  const context = {
+    sendText: jest.fn(() => Promise.resolve()),
+  };
+
+  await action(context);
+
+  expect(context.sendText).toBeCalledWith('haha', {
+    quick_replies: [
+      {
+        content_type: 'text',
+        title: 'Red',
+        payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED',
+      },
+    ],
+    tag: 'ISSUE_RESOLUTION',
+  });
+});
+
+it('should merge multiple attached options', async () => {
+  const action = attachOptions(
+    { tag: 'ISSUE_RESOLUTION' },
+    attachOptions(
+      {
+        quick_replies: [
+          {
+            content_type: 'text',
+            title: 'Red',
+            payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED',
+          },
+        ],
+      },
+      sendText('haha')
+    )
+  );
+  const context = {
+    sendText: jest.fn(() => Promise.resolve()),
+  };
+
+  await action(context);
+
+  expect(context.sendText).toBeCalledWith('haha', {
+    quick_replies: [
+      {
+        content_type: 'text',
+        title: 'Red',
+        payload: 'DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED',
+      },
+    ],
+    tag: 'ISSUE_RESOLUTION',
+  });
+});
+
+it('should create action that will run in curried attachOptions', async () => {
+  const attachIssueResolutionTag = attachOptions({ tag: 'ISSUE_RESOLUTION' });
+  const action = attachIssueResolutionTag(sendText('haha'));
+
+  const context = {
+    sendText: jest.fn(),
+  };
+
+  await action(context);
+
+  expect(context.sendText).toBeCalledWith('haha', { tag: 'ISSUE_RESOLUTION' });
+});

--- a/src/attachOptions.js
+++ b/src/attachOptions.js
@@ -1,0 +1,26 @@
+const curry = require('lodash/curry');
+const warning = require('warning');
+
+const attachOptions = (options, action) => {
+  if (
+    !(
+      typeof action.argsLength === 'number' &&
+      action.argsLength > 0 &&
+      action.allowOptions === true
+    )
+  ) {
+    warning(false, 'attachOptions: cannot attach options to this action');
+
+    return action;
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  action._options = {
+    ...action._options,
+    ...options,
+  };
+
+  return action;
+};
+
+module.exports = curry(attachOptions);


### PR DESCRIPTION
### `attachOptions`

Attaches additional options to the action.

```js
const { attachOptions, sendText } = require('bottender-compose');

bot.onEvent(
  attachOptions({ tag: 'ISSUE_RESOLUTION' }, sendText('Issue Resolved'))
);

// curry function
const attachIssueResolutionTag = attachOptions({ tag: 'ISSUE_RESOLUTION' });

bot.onEvent(attachIssueResolutionTag(sendText('Issue Resolved')));
```