### PR TITLE
improve warning when compiling template

### DIFF
--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -135,7 +135,7 @@ describe('#compileTemplate', () => {
       expectTemplate('Hi, {{context.session.user.first_name}}');
       expect(warning).toBeCalledWith(
         true,
-        'Properties accessors in template is invalid -- expected return a string but got: string'
+        'Properties accessors (context.session.user.first_name) in template is invalid -- expected return a non-empty string but got: string'
       );
     });
 
@@ -145,7 +145,7 @@ describe('#compileTemplate', () => {
       );
       expect(warning).toBeCalledWith(
         false,
-        'Properties accessors in template is invalid -- expected return a string but got: object'
+        'Properties accessors (context.session.user) in template is invalid -- expected return a non-empty string but got: object'
       );
     });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,23 +41,24 @@ exports.compileTemplate = tpl => (context, param) => {
     ] = templateRegExp.exec(matchString);
 
     let value;
+    let properties;
 
     if (firstWhitelistKey === 'param') {
-      value = get(param, otherResults[0].slice(1), '');
+      properties = otherResults[0].slice(1);
+      value = get(param, properties);
     } else {
-      const properties = `${
+      properties = `${
         contextKeyPrefixResolveMap[firstWhitelistKey]
       }${otherResults[0].slice(1)}`;
-
-      value = get(context, properties, '');
+      value = get(context, properties);
     }
 
     warning(
-      typeof value === 'string',
-      `Properties accessors in template is invalid -- expected return a string but got: ${typeof value}`
+      value && typeof value === 'string',
+      `Properties accessors (${firstWhitelistKey}.${properties}) in template is invalid -- expected return a non-empty string but got: ${typeof value}`
     );
 
-    compiledResult = replace(compiledResult, targetString, value);
+    compiledResult = replace(compiledResult, targetString, value || '');
 
     templateRegExp.lastIndex = 0;
   }


### PR DESCRIPTION
Before:

```
Properties accessors in template is invalid -- expected return a string but got: object
```

After:

```
Properties accessors (context.session.user) in template is invalid -- expected return a non-empty string but got: object
```