### PR TITLE
rename param to props in effects and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ setDisplayName('sayHello')(sendText('hello'));
 
 ### `effect()`
 
-Does side effects and mutate state or parameters.
+Does side effects and mutate state or props.
 
 ```js
 const { effect } = require('bottender-compose');
@@ -341,16 +341,16 @@ bot.onEvent(
         derivedState: {
           x: 1,
         },
-        derivedParam: {
+        derivedProps: {
           y: 2,
         },
       };
     },
 
     // action
-    async (context, param) => {
+    async (context, props) => {
       console.log(context.state.x); // 1
-      console.log(param.y); // 2
+      console.log(props.y); // 2
     }
   )
 );
@@ -588,10 +588,10 @@ B.sendText('State: {{state.xxx}}');
 B.sendText('User: {{user.first_name}} {{user.last_name}}');
 ```
 
-Or use `param` to access object values that provided as sencond argument when calling action:
+Or use `props` to access object values that provided as props when calling action:
 
 ```js
-B.sendText('User: {{param.name}}')(context, { name: 'Super User' });
+B.sendText('User: {{props.name}}')(context, { name: 'Super User' });
 ```
 
 ### Predicates

--- a/src/__tests__/effect.spec.js
+++ b/src/__tests__/effect.spec.js
@@ -115,6 +115,82 @@ it('should support derivedParam when have two otherArgs', async () => {
   expect(haha.mock.calls[0][2]).toBe(extraArg2);
 });
 
+it('should support derivedProps when have no otherArgs', async () => {
+  const haha = jest.fn();
+
+  const action = effect(
+    () => ({
+      derivedProps: { x: 1 },
+    }),
+    haha
+  );
+
+  const context = createContext();
+
+  await action(context);
+
+  expect(haha.mock.calls[0][1]).toHaveProperty('x', 1);
+});
+
+it('should support derivedProps when have one otherArg (object)', async () => {
+  const haha = jest.fn();
+
+  const action = effect(
+    () => ({
+      derivedProps: { x: 1 },
+    }),
+    haha
+  );
+
+  const context = createContext();
+
+  const extraArg = {};
+
+  await action(context, extraArg);
+
+  expect(haha.mock.calls[0][1]).toHaveProperty('x', 1);
+});
+
+it('should support derivedProps when have one otherArg (non-object)', async () => {
+  const haha = jest.fn();
+
+  const action = effect(
+    () => ({
+      derivedProps: { x: 1 },
+    }),
+    haha
+  );
+
+  const context = createContext();
+
+  const extraArg = 1;
+
+  await action(context, extraArg);
+
+  expect(haha.mock.calls[0][1]).not.toHaveProperty('x', 1);
+});
+
+it('should support derivedProps when have two otherArgs', async () => {
+  const haha = jest.fn();
+
+  const action = effect(
+    () => ({
+      derivedProps: { x: 1 },
+    }),
+    haha
+  );
+
+  const context = createContext();
+
+  const extraArg = {};
+  const extraArg2 = {};
+
+  await action(context, extraArg, extraArg2);
+
+  expect(haha.mock.calls[0][1]).toHaveProperty('x', 1);
+  expect(haha.mock.calls[0][2]).toBe(extraArg2);
+});
+
 it('should pass extra args to effect fn & action', async () => {
   const haha = jest.fn();
   const doEffect = jest.fn();

--- a/src/__tests__/utils.spec.js
+++ b/src/__tests__/utils.spec.js
@@ -59,9 +59,13 @@ describe('#isValidTemplate', () => {
   it('should support other param', () => {
     expect(isValidTemplate('Hi, {{param.cool}}')).toBe(true);
   });
+
+  it('should support props', () => {
+    expect(isValidTemplate('Hi, {{props.cool}}')).toBe(true);
+  });
 });
 
-function expectTemplate(template, param) {
+function expectTemplate(template, props) {
   const context = {
     session: {
       user: {
@@ -74,7 +78,7 @@ function expectTemplate(template, param) {
     },
   };
 
-  return expect(compileTemplate(template)(context, param));
+  return expect(compileTemplate(template)(context, props));
 }
 
 describe('#compileTemplate', () => {
@@ -128,6 +132,10 @@ describe('#compileTemplate', () => {
 
   it('should support other param', () => {
     expectTemplate('Hi, {{param.name}}', { name: 'James' }).toBe('Hi, James');
+  });
+
+  it('should support props', () => {
+    expectTemplate('Hi, {{props.name}}', { name: 'James' }).toBe('Hi, James');
   });
 
   describe('#warning', () => {

--- a/src/effect.js
+++ b/src/effect.js
@@ -1,14 +1,20 @@
 const curry = require('lodash/curry');
+const warning = require('warning');
 
 const effect = (effectFn, action) => async (context, ...otherArgs) => {
-  const { derivedState, derivedParam } =
+  const { derivedState, derivedParam, derivedProps } =
     (await effectFn(context, ...otherArgs)) || {};
 
   if (derivedState) {
     context.setState(derivedState);
   }
 
-  if (derivedParam) {
+  warning(
+    !derivedParam,
+    '`derivedParam` is deprecated. Use `derivedProps` instead.'
+  );
+
+  if (derivedParam || derivedProps) {
     const [param, ...argsFromIndex2] = otherArgs;
     if (!param || typeof param === 'object') {
       return action(
@@ -16,6 +22,7 @@ const effect = (effectFn, action) => async (context, ...otherArgs) => {
         {
           ...param,
           ...derivedParam,
+          ...derivedProps,
         },
         ...argsFromIndex2
       );

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ const TEMPLATE_WHITELIST_KEYS = [
   'event',
   'state',
   'param',
+  'props',
 ];
 
 const contextKeyPrefixResolveMap = {
@@ -29,7 +30,7 @@ exports.isValidTemplate = str => {
   return templateRegExp.test(str);
 };
 
-exports.compileTemplate = tpl => (context, param) => {
+exports.compileTemplate = tpl => (context, props) => {
   let compiledResult = tpl;
   const templateRegExp = new RegExp(`{{\\s*${JOINED_KEYS}\\s*}}`, 'g');
 
@@ -45,9 +46,14 @@ exports.compileTemplate = tpl => (context, param) => {
     let value;
     let properties;
 
-    if (firstWhitelistKey === 'param') {
+    warning(
+      firstWhitelistKey !== 'params',
+      '`param` is deprecated. Use `props` instead.'
+    );
+
+    if (['param', 'props'].includes(firstWhitelistKey)) {
       properties = otherResults[0].slice(1);
-      value = get(param, properties);
+      value = get(props, properties);
     } else {
       properties = `${
         contextKeyPrefixResolveMap[firstWhitelistKey]


### PR DESCRIPTION
This concept is easier to understand with the state. 

In `effect`:

```js
  effect(
    // function has side effects
    async context => {
      await doSomeSideEffects();
      return {
        derivedState: {
          x: 1,
        },
        derivedProps: {
          y: 2,
        },
      };
    },
    // action
    async (context, props) => {
      console.log(context.state.x); // 1
      console.log(props.y); // 2
    }
  )
```

In template: `Hi, {{props.name}}`